### PR TITLE
31 playlist overview styling

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -40,6 +40,35 @@ h2 {
     min-width: max-content;
 }
 
+/* The "progress bar" on the lessons overview page */
+ol.progress {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    overflow-x: scroll;
+    scrollbar-width: none;
+    margin-bottom: 2rem;
+    scroll-snap-type: x mandatory;
+    padding-inline: 45vw;
+
+    li {
+        width: clamp(15rem, 60vw, 40rem);
+        flex-shrink: 0;
+        border-radius: var(--border-radius);
+        list-style-position: inside;
+        padding: .5rem 1rem;
+        scroll-snap-align: center;
+    }
+
+    li:nth-of-type(1) {
+        background-color: #139943;
+    }
+
+    li:nth-of-type(2) {
+        background-color: #37C6AB;
+    }
+}
+
 /* Styles all cards have in common */
 .playlist-card-vertical,
 .story-card-horizontal {

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -1,0 +1,48 @@
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--font-primary);
+}
+
+body.lessons {
+    /* fallback */
+    background-color: #471871;
+    background-color: var(--background-method);
+}
+
+.playlist-card-vertical {
+    list-style: none;
+    background-color: white;
+    color: black;
+
+    display: grid;
+    grid-template-areas:
+    "image image"
+    "title title"
+    "playtime form";
+
+    height: 18rem;
+    width: 11rem;
+    padding: 1rem;
+
+    >picture {
+        grid-area: image;
+        object-fit: cover;
+    }
+
+    >h3 {
+        grid-area: title;
+        height: 2lh;
+    }
+
+    p {
+        grid-area: playtime;
+    }
+
+    form {
+        grid-area: form;
+        justify-self: end;
+    }
+}

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -139,3 +139,30 @@ ol.progress {
         justify-self: end;
     }
 }
+
+.list-grid,
+.list-horizontal {
+    gap: .5rem;
+    padding-inline-start: 1rem;
+    list-style: none;
+
+    overflow-x: scroll;
+    scrollbar-width: none;
+
+    ::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+.list-grid {
+    display: grid;
+    grid-template-rows: repeat(3, max-content);
+    grid-auto-columns: max-content;
+    grid-auto-flow: column;
+    scroll-snap-type: x mandatory;
+}
+
+.list-horizontal {
+    display: flex;
+    flex-direction: row;
+}

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -40,37 +40,73 @@ h2 {
     min-width: max-content;
 }
 
-.playlist-card-vertical {
+/* Styles all cards have in common */
+.playlist-card-vertical,
+.story-card-horizontal {
+    display: grid;
     list-style: none;
     background-color: white;
     color: black;
+    border-radius: var(--border-radius);
 
-    display: grid;
+    h3 {
+        grid-area: title;
+        margin: 0;
+        align-content: center;
+
+        font-size: 1rem;
+        height: 2lh;
+        color: black;
+        text-wrap: balance;
+    }
+
+    a {
+        color: black;
+    }
+
+    p {
+        grid-area: playtime;
+        margin: 0;
+    }
+
+    picture {
+        grid-area: image;
+
+        img {
+            border-radius: var(--border-radius);
+            object-fit: cover;
+        }
+    }
+}
+
+.playlist-card-vertical {
+    height: 18rem;
+    width: 11rem;
+    padding: 1rem;
     grid-template-areas:
     "image image"
     "title title"
     "playtime form";
 
-    height: 18rem;
-    width: 11rem;
-    padding: 1rem;
-
-    >picture {
-        grid-area: image;
-        object-fit: cover;
-    }
-
-    >h3 {
-        grid-area: title;
-        height: 2lh;
-    }
-
-    p {
-        grid-area: playtime;
-    }
-
     form {
         grid-area: form;
+        justify-self: end;
+    }
+}
+
+.story-card-horizontal {
+    height: 6rem;
+    width: clamp(18rem, 80vw, 22rem);
+    padding: 0.5rem;
+
+    grid-template-columns: min-content 1fr;
+    grid-template-areas:
+    "image title"
+    "image playtime";
+    gap: 0.5rem;
+    scroll-snap-align: center;
+
+    p.language {
         justify-self: end;
     }
 }

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -4,12 +4,40 @@
 
 body {
     font-family: var(--font-primary);
+    color: white;
 }
 
 body.lessons {
     /* fallback */
-    background-color: #471871;
-    background-color: var(--background-method);
+    background: #471871;
+    background: var(--background-method);
+}
+
+header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+a {
+    color: white;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+h1 {
+    width: max-content;
+    margin: 1rem auto;
+}
+
+
+h2 {
+    padding-inline-start: 1rem;
+    min-width: max-content;
 }
 
 .playlist-card-vertical {

--- a/views/lessons.liquid
+++ b/views/lessons.liquid
@@ -1,11 +1,18 @@
 {% render 'partials/head.liquid'
   , title: 'Lessons' %}
 
+{% comment %} TEMPORARY: FOR TESTING PURPOSES {% endcomment %}
+<link rel="stylesheet" href="/styles/style.css">
+<link rel="stylesheet" href="/styles/tumi.css">
+
+<body class="lessons">
+{% comment %} END TEMPORARY {% endcomment %}
+
 <main>
   <header>
     <h1>Lessons</h1>
   </header>
-
+  
   <ol class="progress">
     <li>Listening</li>
     <li>First words</li>

--- a/views/lessons.liquid
+++ b/views/lessons.liquid
@@ -1,6 +1,6 @@
 {% render 'partials/head.liquid'
   , title: 'Lessons' %}
-
+<link rel="stylesheet" href="/styles/style.css">
 <main>
   <h1>Lessons</h1>
   <ol>

--- a/views/lessons.liquid
+++ b/views/lessons.liquid
@@ -1,18 +1,11 @@
 {% render 'partials/head.liquid'
   , title: 'Lessons' %}
 
-{% comment %} TEMPORARY: FOR TESTING PURPOSES {% endcomment %}
-<link rel="stylesheet" href="/styles/style.css">
-<link rel="stylesheet" href="/styles/tumi.css">
-
-<body class="lessons">
-{% comment %} END TEMPORARY {% endcomment %}
-
 <main>
   <header>
     <h1>Lessons</h1>
   </header>
-  
+
   <ol class="progress">
     <li>Listening</li>
     <li>First words</li>

--- a/views/lessons.liquid
+++ b/views/lessons.liquid
@@ -2,8 +2,11 @@
   , title: 'Lessons' %}
 <link rel="stylesheet" href="/styles/style.css">
 <main>
+  <header>
   <h1>Lessons</h1>
-  <ol>
+  </header>
+  
+  <ol class="progress">
     <li>Listening</li>
     <li>First words</li>
   </ol>
@@ -13,7 +16,7 @@
       <a href="">Recommended Stories</a>
     </h2>
 
-    <ul>
+    <ul class="list-grid">
       {% for story in stories %}
         {% render 'partials/story-card.liquid'
           , story: story %}
@@ -28,15 +31,13 @@
       <a href="">Your Playlists</a>
     </h2>
 
-    <ul>
+    <ul class="list-horizontal">
       {% for playlist in yourPlaylists %}
         {% render 'partials/playlist-card.liquid'
           , playlist: playlist %}
-      {% else %}
-        <li>No playlists found.</li>
       {% endfor %}
 
-      <li>
+      <li class="playlist-card-vertical">
         <a href="">
           <img
             class="plus"
@@ -55,19 +56,16 @@
       <a href="">All Stories</a>
     </h2>
 
-    <ul>
+    <ul class="list-horizontal">
       <li>
-        <a href="/stories/filter?language=1">English</a>
+        <a href="/stories/filter?language=1" class="button-standard white">English</a>
       </li>
       <li>
-        <a href="/stories/filter?language=2">Dutch</a>
-      </li>
-      <li>
-        <a href="/stories">View All</a>
+        <a href="/stories/filter?language=2" class="button-standard white">Dutch</a>
       </li>
     </ul>
 
-    <ul>
+    <ul class="list-grid">
       {% for story in stories %}
         {% render 'partials/story-card.liquid'
           , story: story %}
@@ -82,7 +80,7 @@
       <a href="">Liked Playlists</a>
     </h2>
 
-    <ul>
+    <ul class="list-horizontal">
       {% for playlist in likedPlaylists %}
         {% render 'partials/playlist-card.liquid'
           , playlist: playlist
@@ -98,7 +96,7 @@
       <a href="">Suggested Playlists</a>
     </h2>
 
-    <ul>
+    <ul class="list-horizontal">
       {% for playlist in suggestedPlaylists %}
         {% render 'partials/playlist-card.liquid'
           , playlist: playlist

--- a/views/lessons.liquid
+++ b/views/lessons.liquid
@@ -1,9 +1,16 @@
 {% render 'partials/head.liquid'
   , title: 'Lessons' %}
+
+{% comment %} TEMPORARY: FOR TESTING PURPOSES {% endcomment %}
 <link rel="stylesheet" href="/styles/style.css">
+<link rel="stylesheet" href="/styles/tumi.css">
+
+<body class="lessons">
+{% comment %} END TEMPORARY {% endcomment %}
+
 <main>
   <header>
-  <h1>Lessons</h1>
+    <h1>Lessons</h1>
   </header>
   
   <ol class="progress">

--- a/views/partials/playlist-card.liquid
+++ b/views/partials/playlist-card.liquid
@@ -1,4 +1,4 @@
-<li>
+<li class="playlist-card-vertical">
   <h3>
     <a href="lessons/playlist/{{ playlist.id }}">{{ playlist.title }}</a>
   </h3>

--- a/views/partials/playlist-card.liquid
+++ b/views/partials/playlist-card.liquid
@@ -11,7 +11,7 @@
       width="144">
   </picture>
 
-  <p>{{ playlist.playtime }}</p>
+  <p class="playtime">{{ playlist.playtime | default: "0m 0s" }}</p>
 
   {% if action == "like" %}
     <form method="post" action="/124/{{ playlist.id }}/like">

--- a/views/partials/story-card.liquid
+++ b/views/partials/story-card.liquid
@@ -1,4 +1,4 @@
-<li>
+<li class="story-card-horizontal">
   <h3>
     <a href="lessons/story/{{ story.id }}">{{ story.title }}</a>
   </h3>
@@ -11,6 +11,6 @@
       width="80">
   </picture>
 
-  <p>{{ story.language.language }}</p>
-  <p>{{ story.playtime }}</p>
+  <p class="language">{{ story.language.language }}</p>
+  <p class="playtime">{{ story.playtime }}</p>
 </li>


### PR DESCRIPTION
### What does this change?

Resolves issue #31: 
- adds basic styling to the lessons overview page.
- adds classes for different types of cards and lists.

### How Has This Been Tested?
I have viewed the page in a Firefox-based browser and confirmed nothing looked off.

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [ ] Browser test

### Images

![image](https://github.com/user-attachments/assets/19e5145f-bddd-418d-bebb-3742bab1a573)
![image](https://github.com/user-attachments/assets/505fce45-b64c-4e1c-bf44-9ef3d6b9fc02)


### How to review
- check the css for mistakes, completeness and/or redundancy
- check the page in different browsers
- check the page in different viewports