### PR TITLE
34 story detail page styling

### DIFF
--- a/public/assets/pause.svg
+++ b/public/assets/pause.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <path stroke="#000000" stroke-linejoin="round" stroke-width="2" d="M6 6h4v12H6V6ZM14 6h4v12h-4V6Z"/>
+</svg>

--- a/public/assets/plus.svg
+++ b/public/assets/plus.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <g stroke="#000000" stroke-linecap="round" stroke-width="2">
+    <path d="M12 19V5"/>
+    <path d="M19 12H5"/>
+  </g>
+</svg>

--- a/public/assets/volume-off.svg
+++ b/public/assets/volume-off.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <g stroke="#000000" stroke-width="2">
+    <path stroke-linejoin="round" d="M7 9H4v6h3l5 4V5L7 9z"/>
+    <path stroke-linecap="round" d="M16 9.5l5 5"/>
+    <path stroke-linecap="round" d="M21 9.5l-5 5"/>
+  </g>
+</svg>

--- a/public/assets/volume.svg
+++ b/public/assets/volume.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <g stroke="#000000" stroke-width="2">
+    <path stroke-linejoin="round" d="M6 9H3v6h3l5 4V5L6 9z"/>
+    <path stroke-linecap="round" d="M18.5 5.5a9.192 9.192 0 010 13"/>
+    <path stroke-linecap="round" d="M15 8a5.657 5.657 0 010 8"/>
+  </g>
+</svg>

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -5,6 +5,7 @@
 body {
     font-family: var(--font-primary);
     color: white;
+    min-height: 100dvh;
 }
 
 body.lessons {

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -16,6 +16,7 @@ body.lessons {
 header {
     display: flex;
     flex-direction: row;
+    align-items: center;
     justify-content: space-between;
 }
 
@@ -33,7 +34,6 @@ h1 {
     width: max-content;
     margin: 1rem auto;
 }
-
 
 h2 {
     padding-inline-start: 1rem;
@@ -113,9 +113,9 @@ ol.progress {
     width: 11rem;
     padding: 1rem;
     grid-template-areas:
-    "image image"
-    "title title"
-    "playtime form";
+        "image image"
+        "title title"
+        "playtime form";
 
     form {
         grid-area: form;
@@ -130,8 +130,8 @@ ol.progress {
 
     grid-template-columns: min-content 1fr;
     grid-template-areas:
-    "image title"
-    "image playtime";
+        "image title"
+        "image playtime";
     gap: 0.5rem;
     scroll-snap-align: center;
 
@@ -165,4 +165,84 @@ ol.progress {
 .list-horizontal {
     display: flex;
     flex-direction: row;
+}
+
+.active-story {
+    label {
+        min-width: max-content;
+    }
+
+    picture {
+        display: block;
+        margin: .5rem auto 1rem auto;
+        width: fit-content;
+
+        img {
+            width: min(20rem, 90vw);
+            object-fit: cover;
+            border-radius: var(--border-radius);
+            border: 4px solid white;
+        }
+    }
+
+    audio {
+        margin: .5rem auto;
+    }
+
+    p {
+        width: min(20rem, 90vw);
+        margin: 0 auto;
+        font-size: clamp(1rem, 10vw, 2rem);
+        height: 1lh;
+        text-align: center;
+    }
+
+    progress {
+        display: block;
+        margin: .5rem auto;
+    }
+}
+
+audio {
+    display: block;
+}
+
+.audio-controls-container {
+    width: min(20rem, 90vw);
+    margin: 2rem auto .5rem auto;
+    display: flex;
+    justify-content: space-evenly;
+}
+
+.progress-label {
+    display: block;
+    margin: .5rem auto;
+    width: fit-content;
+
+    span {
+        margin-left: .5rem;
+    }
+
+    progress {
+        display: inline-block;
+        margin: 0;
+        appearance: none;
+        border-radius: var(--border-radius);
+        inline-size: 20rem;
+        block-size: .5rem;
+    }
+
+    progress[value]::-webkit-progress-bar {
+        background-color: #00000025;
+        border-radius: var(--border-radius);
+    }
+
+    progress[value]::-webkit-progress-value {
+        background-color: var(--lessons-primary);
+        border-radius: var(--border-radius);
+    }
+}
+
+.hidden {
+    display: none;
 }

--- a/views/story.liquid
+++ b/views/story.liquid
@@ -1,42 +1,151 @@
 {% render 'partials/head.liquid'
   , title: 'Lessons' %}
 
-<main>
-  <a href="/lessons">Back</a>
-  <label><input type="checkbox">Night mode</label>
+{% comment %} TEMPORARY {% endcomment %}
+<link rel="stylesheet" href="/styles/style.css">
+<link rel="stylesheet" href="/styles/tumi.css">
 
-  <picture>
-    <img src="https://fdnd-agency.directus.app/assets/{{ story.image.id | default: "0e52b9bc-fc22-415b-a102-4b7af0e18442" }}" alt="{{ story.image.title }}">
-  </picture>
+<body class="lessons">
+  {% comment %} END TEMPORARY {% endcomment %}
 
+  <main class="active-story">
+    <header>
+      <a href="/lessons" class="button-icon">
+        <svg
+          width="800px"
+          height="800px"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none">
+          <path
+            stroke="#FFFFFF"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M14 5l-7 7 7 7" />
+        </svg>
+        Back</a>
 
-  {% if story.audio[0].audio_file %}
-    <p class="previous-subtitle"></p>
-    <p class="subtitle"></p>
+      <label><input type="checkbox">Night mode</label>
+    </header>
 
-    <audio
-      controls
-      crossorigin="anonymous"
-      src="https://fdnd-agency.directus.app/assets/{{ story.audio[0].audio_file }}">
-      <track
-        default
-        kind="captions"
-        srclang="en"
-        src="https://fdnd-agency.directus.app/assets/{{ story.audio[0].transcript_file }}" />
-    </audio>
+    <picture>
+      <img src="https://fdnd-agency.directus.app/assets/{{ story.image.id | default: "0e52b9bc-fc22-415b-a102-4b7af0e18442" }}" alt="{{ story.image.title }}">
+    </picture>
 
-    <progress max="100" value="60">60%</progress>
-  {% else %}
-    <p>No audio was found for this story.</p>
-  {% endif %}
-</main>
+    {% if story.audio[0].audio_file %}
+      <p class="previous-subtitle"></p>
+      <p class="subtitle"></p>
 
-<script>
-  // https://stackoverflow.com/questions/23475335/subtitles-for-audio-with-track-how-to-display-the-subtitles
-  document.querySelector('audio').textTracks[0].addEventListener('cuechange', function() {
-  document.querySelector('.previous-subtitle').innerText = document.querySelector('.subtitle').innerText;
-  document.querySelector('.subtitle').innerText = this.activeCues[0].text;
-  });
-</script>
+      <div class="audio-controls-container">
+        <button class="button-round purple button-play hidden">
+          <svg
+            class="play"
+            width="800px"
+            height="800px"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="#FFFFFF">
+            <path
+              stroke="#FFFFFF"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M7 17.259V6.741a1 1 0 0 1 1.504-.864l9.015 5.26a1 1 0 0 1 0 1.727l-9.015 5.259A1 1 0 0 1 7 17.259Z" />
+          </svg>
 
-{% render 'partials/foot.liquid' %}
+          <svg
+            class="pause hidden"
+            width="800px"
+            height="800px"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="#FFFFFF">
+            <path
+              stroke="#FFFFFF"
+              stroke-linejoin="round"
+              stroke-width="1"
+              d="M6 6h4v12H6V6ZM14 6h4v12h-4V6Z" />
+          </svg>
+        </button>
+
+        <button class="button-round purple">
+          <svg
+            width="800px"
+            height="800px"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none">
+            <g stroke="#FFFFFF" stroke-width="2">
+              <path stroke-linejoin="round" d="M6 9H3v6h3l5 4V5L6 9z" />
+              <path stroke-linecap="round" d="M18.5 5.5a9.192 9.192 0 010 13" />
+              <path stroke-linecap="round" d="M15 8a5.657 5.657 0 010 8" />
+            </g>
+          </svg>
+        </button>
+      </div>
+
+      <audio
+        controls
+        crossorigin="anonymous"
+        src="https://fdnd-agency.directus.app/assets/{{ story.audio[0].audio_file }}">
+        <track
+          default
+          kind="captions"
+          srclang="en"
+          src="https://fdnd-agency.directus.app/assets/{{ story.audio[0].transcript_file }}" />
+      </audio>
+
+      <label class="progress-label">
+        <progress max="100" value="60"></progress>
+        <span>0</span>%
+      </label>
+
+    {% else %}
+      <p>No audio was found for this story.</p>
+    {% endif %}
+  </main>
+
+  <script>
+      // https://stackoverflow.com/questions/23475335/subtitles-for-audio-with-track-how-to-display-the-subtitles
+      document.querySelector('audio').textTracks[0].addEventListener('cuechange', function() {
+      document.querySelector('.previous-subtitle').innerText = document.querySelector('.subtitle').innerText;
+      document.querySelector('.subtitle').innerText = this.activeCues[0].text;
+      });
+  </script>
+
+  <script>
+    let playButton = document.querySelector('.button-play');
+    let playIcon = document.querySelector('.play');
+    let pauseIcon = document.querySelector('.pause');
+    let audio = document.querySelector('audio');
+    let audioProgress = document.querySelector('progress');
+    let audioProgressText = document.querySelector('progress + span')
+    
+    playButton.addEventListener('click', toggleAudio);
+    
+    function toggleAudio() {
+      if (audio.paused) {
+        audio.play();
+        pauseIcon.classList.remove('hidden');
+        playIcon.classList.add('hidden');
+      } else {
+        audio.pause();
+        playIcon.classList.remove('hidden');
+        pauseIcon.classList.add('hidden');
+      }
+    }
+    
+    playButton.classList.remove('hidden');
+    audio.classList.add('hidden');
+    
+    audio.addEventListener("timeupdate", function() {
+    let currentTime = audio.currentTime;
+    let duration = audio.duration;
+    let percentage = Math.round(currentTime / duration * 100);
+    audioProgress.value = percentage;
+    audioProgressText.innerHTML = percentage;
+    });
+  </script>
+
+  {% render 'partials/foot.liquid' %}

--- a/views/story.liquid
+++ b/views/story.liquid
@@ -69,8 +69,9 @@
           </svg>
         </button>
 
-        <button class="button-round purple">
+        <button class="button-round button-mute purple">
           <svg
+            class="mute-icon"
             width="800px"
             height="800px"
             viewBox="0 0 24 24"
@@ -80,6 +81,19 @@
               <path stroke-linejoin="round" d="M6 9H3v6h3l5 4V5L6 9z" />
               <path stroke-linecap="round" d="M18.5 5.5a9.192 9.192 0 010 13" />
               <path stroke-linecap="round" d="M15 8a5.657 5.657 0 010 8" />
+            </g>
+          </svg>
+          <svg
+            class="unmute-icon hidden"
+            width="800px"
+            height="800px"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none">
+            <g stroke="#FFFFFF" stroke-width="2">
+              <path stroke-linejoin="round" d="M7 9H4v6h3l5 4V5L7 9z" />
+              <path stroke-linecap="round" d="M16 9.5l5 5" />
+              <path stroke-linecap="round" d="M21 9.5l-5 5" />
             </g>
           </svg>
         </button>
@@ -97,7 +111,7 @@
       </audio>
 
       <label class="progress-label">
-        <progress max="100" value="60"></progress>
+        <progress max="100" value="0"></progress>
         <span>0</span>%
       </label>
 
@@ -116,13 +130,21 @@
 
   <script>
     let playButton = document.querySelector('.button-play');
+    let muteButton = document.querySelector('.button-mute');
+    
     let playIcon = document.querySelector('.play');
     let pauseIcon = document.querySelector('.pause');
+    
+    let muteIcon = document.querySelector('.mute-icon');
+    let unmuteIcon = document.querySelector('.unmute-icon');
+    
     let audio = document.querySelector('audio');
     let audioProgress = document.querySelector('progress');
-    let audioProgressText = document.querySelector('progress + span')
+    let audioProgressText = document.querySelector('progress + span');
     
     playButton.addEventListener('click', toggleAudio);
+    muteButton.addEventListener('click', toggleSound);
+    audio.addEventListener("timeupdate", updateProgress);
     
     function toggleAudio() {
       if (audio.paused) {
@@ -134,18 +156,30 @@
         playIcon.classList.remove('hidden');
         pauseIcon.classList.add('hidden');
       }
+    };
+    
+    function toggleSound() {
+      if (audio.muted) {
+        audio.muted = false;
+        unmuteIcon.classList.add('hidden');
+        muteIcon.classList.remove('hidden');
+      } else {
+        audio.muted = true;
+        muteIcon.classList.add('hidden');
+        unmuteIcon.classList.remove('hidden');
+      }
+    };
+    
+    function updateProgress() {
+      let currentTime = audio.currentTime;
+      let duration = audio.duration;
+      let percentage = Math.round(currentTime / duration * 100);
+      audioProgress.value = percentage;
+      audioProgressText.innerHTML = percentage;
     }
     
     playButton.classList.remove('hidden');
     audio.classList.add('hidden');
-    
-    audio.addEventListener("timeupdate", function() {
-    let currentTime = audio.currentTime;
-    let duration = audio.duration;
-    let percentage = Math.round(currentTime / duration * 100);
-    audioProgress.value = percentage;
-    audioProgressText.innerHTML = percentage;
-    });
   </script>
 
   {% render 'partials/foot.liquid' %}

--- a/views/story.liquid
+++ b/views/story.liquid
@@ -123,8 +123,8 @@
   <script>
       // https://stackoverflow.com/questions/23475335/subtitles-for-audio-with-track-how-to-display-the-subtitles
       document.querySelector('audio').textTracks[0].addEventListener('cuechange', function() {
-      document.querySelector('.previous-subtitle').innerText = document.querySelector('.subtitle').innerText;
-      document.querySelector('.subtitle').innerText = this.activeCues[0].text;
+        document.querySelector('.previous-subtitle').innerText = document.querySelector('.subtitle').innerText;
+        document.querySelector('.subtitle').innerText = this.activeCues[0].text;
       });
   </script>
 


### PR DESCRIPTION
### What does this change?

Resolves issue #34
- adds styles for the story detail page
- adds custom audio controls

### How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [ ] Responsive Design test
- [ ] Device test
- [x] Browser test

### Images

![image](https://github.com/user-attachments/assets/e4d19922-0f97-4909-bf58-8fb4f8c00953)
![image](https://github.com/user-attachments/assets/7fa28ff4-158d-4bc7-9b98-de10dd6f4536)

### How to review

Check if it looks right and works well in your browser. Check the code for errors and/or inconsistencies.

### Unresolved tasks
- I will address night mode in another, lower priority issue.
- I will research whether it is possible to jump back and forth through the audio file by clicking on the progress bar. 
- I will make a seperate, low-priority issues for the clouds at the bottom of the screen.