### PR TITLE
33 tweak house style stylesheet

### DIFF
--- a/public/huisstijl.html
+++ b/public/huisstijl.html
@@ -38,8 +38,8 @@
   <button class="button-scroll blue">&lt;</button>
   <button class="button-scroll blue" disabled>&gt;</button>
   <button class="button-wide green">Wide button</button>
-  <button class="button-icon red">Icon 1 (img)<img src="assets/times-circle.svg" alt=""></button>
-  <button class="button-icon purple">
+  <button class="button-standard red">Icon 1 (img)<img src="assets/times-circle.svg" alt=""></button>
+  <button class="button-standard purple">
     <svg width="800px" height="800px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none">
       <path stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
         d="M7 17.259V6.741a1 1 0 0 1 1.504-.864l9.015 5.26a1 1 0 0 1 0 1.727l-9.015 5.259A1 1 0 0 1 7 17.259Z" />

--- a/public/styles/tumi.css
+++ b/public/styles/tumi.css
@@ -174,51 +174,40 @@ body {
     }
 }
 
-/* A big round button */
-.button-round {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 3rem;
-    width: 3rem;
-    border-radius: 100%;
-
-    >img,
-    >svg {
-        height: 100%;
-        width: 100%;
-    }
-}
-
-/* A big square button */
-.button-square {
-    display: flex;
-    align-content: center;
-    justify-content: center;
-    height: 3rem;
-    width: 3rem;
-
-    >img,
-    >svg {
-        height: 100%;
-        width: 100%;
-    }
-}
-
-/* A button that takes up the entire width of the screen */
-.button-wide {
-    width: 100%;
-    text-align: center;
-}
-
-/* A button that contains an icon */
-.button-icon {
+.button-standard {
     >img,
     >svg {
         vertical-align: bottom;
         height: 1.5rem;
         max-width: 1.5rem;
     }
+}
+
+/* Styles that the big round and big square button share*/
+.button-round,
+.button-square {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 3rem;
+    width: 3rem;
+    
+    >img,
+    >svg {
+        height: 100%;
+        width: 100%;
+    }
+}
+
+/* A big round button */
+.button-round {
+    border-radius: 100%;
+}
+
+/* A button that takes up the entire width of the screen */
+.button-wide {
+    width: 100%;
+    text-align: center;
 }
 
 /* Scroll buttons for navigating through the story overview */

--- a/public/styles/tumi.css
+++ b/public/styles/tumi.css
@@ -26,6 +26,10 @@
     --confirm-primary: #27B16F;
     --deny-primary: #D51D1D;
 
+    /* Miscellaneous colors */
+    --black-primary: #000000;
+    --white-primary: #FFFFFF;
+
     /* Menu colors */
     --menu-home-primary: #3F92B6;
     --menu-home-secondary: #3D7A95;
@@ -166,6 +170,7 @@ body {
     }
 
     &:hover {
+        text-decoration: none;
         outline: 2px solid black;
     }
 }

--- a/public/styles/tumi.css
+++ b/public/styles/tumi.css
@@ -98,7 +98,6 @@ body {
     &.white {
         color: black;
         background-color: white;
-        box-shadow: var(--box-shadow-standard);
     }
 
     /* Different menu colors for the navigation buttons */


### PR DESCRIPTION
### What does this change?

Resolves issue #33

- Added text-decoration: none to the button classes on hover. 
- Removed box-shadow from white buttons.
- Merged button-icon with button-standard
- Added variables for black and white
- Compacted some code for buttons that shared the same styles

### How Has This Been Tested?
I have confirmed with the huisstijl.html page that everything still looks the same.

### How to review
Check in tumi.css if the styles are complete. Check your own pages to confirm nothing is broken.
